### PR TITLE
Fixed typo in the footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -427,7 +427,7 @@
                 <footer>
                     <footer class="family-secondary support content">
                         <p class=pb-2>
-                           The source code for this website is <a href="https://github.com/milesmcc/cs106s">available on GitHub</a>, licensed under Apache 2.0. To learn more about CS + Social Gooooood, visit our website at <a href="https://cs4good.org">cs4good.org</a>.</p>
+                           The source code for this website is <a href="https://github.com/milesmcc/cs106s">available on GitHub</a>, licensed under Apache 2.0. To learn more about CS + Social Good, visit our website at <a href="https://cs4good.org">cs4good.org</a>.</p>
                         </p>
                     </footer>
                 </footer>


### PR DESCRIPTION
**Problem**

Find a typo in the footer of the webpage. It says "CS + Social Gooooood".

**Solution**

Changed from "CS + Social Gooooood" to "CS + Social Good". 😄